### PR TITLE
Return true when language key is EN

### DIFF
--- a/Classes/Hooks/FormHooks.php
+++ b/Classes/Hooks/FormHooks.php
@@ -63,6 +63,10 @@ class FormHooks
      */
     protected function isLoadedLanguageVersion($langKey)
     {
+        if ($langKey === 'en') {
+            return true;
+        }
+
         return ExtensionManagementUtility::isLoaded('static_info_tables_' . $langKey);
     }
 


### PR DESCRIPTION
While the language "en" is part of main extension "static_info_tables", it's no way to check for language extension. While language key is "en", the language version check should return true.